### PR TITLE
Update config.toml to support more path_suffixes

### DIFF
--- a/languages/just/config.toml
+++ b/languages/just/config.toml
@@ -1,5 +1,12 @@
 name = "Just"
 grammar = "just"
-path_suffixes = ["justfile", "JUSTFILE", ".justfile"]
+path_suffixes = [
+    "justfile",
+    "Justfile",
+    "JUSTFILE",
+    ".justfile",
+    ".Justfile",
+    ".JUSTFILE",
+]
 line_comments = ["# "]
 brackets = [{ start = "(", end = ")", close = true, newline = true }]


### PR DESCRIPTION
After this PR, Justfile can match more naming formats.