### PR TITLE
Bump to v0.1.1

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "just"
 name = "Justfile"
 description = "Justfile syntax highlighting"
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["Jack T. <jack@jackt.space>"]
 repository = "https://github.com/jackTabsCode/zed-just"


### PR DESCRIPTION
There are a few commits made without a bump in version. I would like to use these officially from the Zed editor, but I think the version would need to be bumped to update the submodule in [zed-industries/extensions](https://github.com/zed-industries/extensions).