### PR TITLE
Add basic outline support (symbols) for recipes

### DIFF
--- a/languages/just/outline.scm
+++ b/languages/just/outline.scm
@@ -1,0 +1,1 @@
+(recipe_header name: (_) @name) @item


### PR DESCRIPTION
Hi! Thanks for creating an extension for Justifies. This pull request adds a basic outline support for recipes. I am attaching a simple video to show how it looks in action. I also plan to add support for running recipes via tasks in Zed but there is a small glitch that I would like resolve first. Thanks!


https://github.com/user-attachments/assets/7a4491f5-c893-43cd-8784-27843aac62b3

