### PR TITLE
feat: support for module file extensions (.just)

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "just"
 name = "Justfile"
 description = "Justfile syntax highlighting"
-version = "0.1.3"
+version = "0.1.2"
 schema_version = 1
 authors = ["Jack T. <jack@jackt.space>"]
 repository = "https://github.com/jackTabsCode/zed-just"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "just"
 name = "Justfile"
 description = "Justfile syntax highlighting"
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["Jack T. <jack@jackt.space>"]
 repository = "https://github.com/jackTabsCode/zed-just"

--- a/languages/just/config.toml
+++ b/languages/just/config.toml
@@ -7,6 +7,7 @@ path_suffixes = [
     ".justfile",
     ".Justfile",
     ".JUSTFILE",
+    ".just",
 ]
 line_comments = ["# "]
 brackets = [{ start = "(", end = ")", close = true, newline = true }]


### PR DESCRIPTION
This PR adds support for module file extensions (`.just`).

> If a module is named foo, just will search for the module file in foo.just, foo/mod.just, foo/justfile, and foo/.justfile. In the latter two cases, the module file may have any capitalization.

[Modules documentation](https://just.systems/man/en/modules1190.html#modules1190)