### PR TITLE
Add support for running Just recipes

### DIFF
--- a/languages/just/runnables.scm
+++ b/languages/just/runnables.scm
@@ -1,0 +1,4 @@
+(
+    (recipe_header name: (_) @run)
+    (#set! tag just-recipe)
+)

--- a/languages/just/tasks.json
+++ b/languages/just/tasks.json
@@ -1,0 +1,9 @@
+[
+  {
+    "label": "$ZED_SYMBOL",
+    "command": "just \"$ZED_SYMBOL\"",
+    "tags": [
+      "just-recipe"
+    ]
+  }
+]


### PR DESCRIPTION
Hi, I decided to open a pull request that adds support for running Just recipes within the editor buffer. Although there is one small nasty issue with jumping "Run" buttons when you type something in the editor. I suspect this is something related to the Justfile tree-sitter grammar. I will have a look into it but here is the pull request anyway. Thanks!


https://github.com/user-attachments/assets/fbcc21bd-fc96-4ae0-8111-e118f8d07dac

