### PR TITLE
fix: path_suffixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /grammars/*
 justfile
+!tests/justfile
 .DS_Store

--- a/languages/just/config.toml
+++ b/languages/just/config.toml
@@ -1,13 +1,5 @@
 name = "Just"
 grammar = "just"
-path_suffixes = [
-    "justfile",
-    "Justfile",
-    "JUSTFILE",
-    ".justfile",
-    ".Justfile",
-    ".JUSTFILE",
-    ".just",
-]
+path_suffixes = ["justfile", "Justfile", "JUSTFILE", "just"]
 line_comments = ["# "]
 brackets = [{ start = "(", end = ")", close = true, newline = true }]

--- a/tests/foo.just
+++ b/tests/foo.just
@@ -1,0 +1,3 @@
+# Comment
+echo msg:
+    @echo msg

--- a/tests/foo.justfile
+++ b/tests/foo.justfile
@@ -1,0 +1,3 @@
+# Comment
+echo msg:
+    @echo msg

--- a/tests/just
+++ b/tests/just
@@ -1,0 +1,3 @@
+# Comment
+echo msg:
+    @echo msg

--- a/tests/justfile
+++ b/tests/justfile
@@ -1,0 +1,3 @@
+# Comment
+echo msg:
+    @echo msg


### PR DESCRIPTION
I found out that the language_for_file_internal [implementation](https://github.com/zed-industries/zed/blob/v0.156.1/crates/language/src/language_registry.rs#L632) does not match the [documentation](https://zed.dev/docs/extensions/languages#language-metadata) about path_suffixes. Instead of suffixes that support glob patterns, they are extension names (without including the dot), and names of hidden files (i.e. files that start with a dot).

 So, `.just` has to be changed to `just`; and `.justfile`, `.Justfile`, and `.JUSTFILE` aren't required.

Wildcards don't work either. The current best solution for that is using `file_types` in `settings.json`.

I added a folder with tests.