### PR TITLE
fix: run tasks from justfiles in other directories

### DIFF
--- a/languages/just/tasks.json
+++ b/languages/just/tasks.json
@@ -1,9 +1,7 @@
 [
   {
     "label": "$ZED_SYMBOL",
-    "command": "just \"$ZED_SYMBOL\"",
-    "tags": [
-      "just-recipe"
-    ]
+    "command": "(cd \"$ZED_DIRNAME\" && just \"$ZED_SYMBOL\")",
+    "tags": ["just-recipe"]
   }
 ]


### PR DESCRIPTION
According to [Invoking justfiles in Other Directories](https://just.systems/man/en/invoking-justfiles-in-other-directories.html#invoking-justfiles-in-other-directories)

This PR can be tested with the test files in https://github.com/jackTabsCode/zed-just/pull/12

<img width="720" alt="image" src="https://github.com/user-attachments/assets/66cc05c7-37ae-4e22-ab0a-cf571cb02ae2">
