### PR TITLE
tasks: Don't wrap command in parenthesis

### DIFF
--- a/languages/just/tasks.json
+++ b/languages/just/tasks.json
@@ -1,7 +1,7 @@
 [
   {
     "label": "$ZED_SYMBOL",
-    "command": "(cd \"$ZED_DIRNAME\" && just \"$ZED_SYMBOL\")",
+    "command": "cd \"$ZED_DIRNAME\" && just \"$ZED_SYMBOL\"",
     "tags": ["just-recipe"]
   }
 ]


### PR DESCRIPTION
In the current version, this breaks when your system shell is fish.

This invocation translates into something like:

```
$ fish -i -c '(cd ~ && true)'
fish: command substitutions not allowed in command position. Try var=(your-cmd) $var ...
(cd ~ && true)
^~~~~~~~~~~~~^
```

Which is invalid fish syntax. Without the parenthesis this works correctly. I also confirmed this works correctly in both bash and zsh.

In bash and zsh, the presence of parenthesis here creates a subshell, but the entire command itself is already invoked as a subshell, so the extra subshell isn't necessary.