### PR TITLE
Update tree-sitter grammer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "just"
@@ -411,27 +411,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
@@ -475,15 +469,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -521,9 +515,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -571,9 +565,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -821,3 +815,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"

--- a/extension.toml
+++ b/extension.toml
@@ -10,8 +10,8 @@ authors = [
 repository = "https://github.com/jackTabsCode/zed-just"
 
 [grammars.just]
-repository = "https://github.com/IndianBoy42/tree-sitter-just"
-commit = "bb0c898a80644de438e6efe5d88d30bf092935cd"
+repository = "https://github.com/mattrobenolt/tree-sitter-just"
+rev = "a2e0c786fa90ac1e85dc40708b2ab277c007f55e"
 
 [language_servers.just-lsp]
 name = "just-lsp"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765248027,
-        "narHash": "sha256-ngar+yP06x3+2k2Iey29uU0DWx5ur06h3iPBQXlU+yI=",
+        "lastModified": 1767840362,
+        "narHash": "sha256-ZtsFqUhilubohNZ1TgpQIFsi4biZTwRH9rjZsDRDik8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7b50ad68415ae5be7ee4cc68fa570c420741b644",
+        "rev": "d159ea1fc321c60f88a616ac28bab660092a227d",
         "type": "github"
       },
       "original": {

--- a/languages/just/highlights.scm
+++ b/languages/just/highlights.scm
@@ -111,39 +111,41 @@
 (shebang) @keyword.directive
 
 ; highlight known settings (filtering does not always work)
+; source: https://just.systems/man/en/settings.html
 (setting
   left: (identifier) @keyword
   (#any-of? @keyword
     "allow-duplicate-recipes"
+    "allow-duplicate-variables"
     "dotenv-filename"
     "dotenv-load"
+    "dotenv-override"
     "dotenv-path"
+    "dotenv-required"
     "export"
     "fallback"
     "ignore-comments"
     "positional-arguments"
+    "quiet"
+    "script-interpreter"
     "shell"
-    "tempdi"
+    "tempdir"
+    "unstable"
     "windows-powershell"
-    "windows-shell"))
+    "windows-shell"
+    "working-directory"))
 
 ; highlight known attributes (filtering does not always work)
+; source: https://just.systems/man/en/attributes.html
 (attribute
   (identifier) @attribute
   (#any-of? @attribute
-    "allow-duplicate-recipes"
+    "arg"
     "confirm"
     "default"
     "doc"
-    "dotenv-filename"
-    "dotenv-load"
-    "dotenv-path"
-    "exit-message"
-    "export"
     "extension"
-    "fallback"
     "group"
-    "ignore-comments"
     "linux"
     "macos"
     "metadata"
@@ -155,12 +157,8 @@
     "positional-arguments"
     "private"
     "script"
-    "shell"
-    "tempdi"
     "unix"
     "windows"
-    "windows-powershell"
-    "windows-shell"
     "working-directory"))
 
 ; Numbers are part of the syntax tree, even if disallowed

--- a/languages/just/injections.scm
+++ b/languages/just/injections.scm
@@ -84,16 +84,16 @@
 (recipe_body ;
   (shebang ;
     (language) @injection.language)
-  (#not-any-of? @injection.language "python3" "nodejs" "node")
+  (#not-any-of? @injection.language "python3" "uv" "nodejs" "node" "bun" "ts" "tsx" "deno" "sh" "zsh" "fish" "pwsh" "pwsh.exe" "powershell" "powershell.exe")
   (#set! injection.include-children)) @injection.content
 
 ; Transform some known executables
 
-; python3 -> python
+; python3/uv -> python
 (recipe_body
   (shebang
     (language) @_lang)
-  (#eq? @_lang "python3")
+  (#any-of? @_lang "python3" "uv")
   (#set! injection.language "python")
   (#set! injection.include-children)) @injection.content
 
@@ -103,4 +103,36 @@
     (language) @_lang)
   (#any-of? @_lang "node" "nodejs")
   (#set! injection.language "javascript")
+  (#set! injection.include-children)) @injection.content
+
+; bun -> javascript
+(recipe_body
+  (shebang
+    (language) @_lang)
+  (#eq? @_lang "bun")
+  (#set! injection.language "javascript")
+  (#set! injection.include-children)) @injection.content
+
+; ts/tsx/deno -> typescript
+(recipe_body
+  (shebang
+    (language) @_lang)
+  (#any-of? @_lang "ts" "tsx" "deno")
+  (#set! injection.language "typescript")
+  (#set! injection.include-children)) @injection.content
+
+; sh/zsh/fish -> bash
+(recipe_body
+  (shebang
+    (language) @_lang)
+  (#any-of? @_lang "sh" "zsh" "fish")
+  (#set! injection.language "bash")
+  (#set! injection.include-children)) @injection.content
+
+; pwsh/powershell (with or without .exe) -> powershell
+(recipe_body
+  (shebang
+    (language) @_lang)
+  (#any-of? @_lang "pwsh" "pwsh.exe" "powershell" "powershell.exe")
+  (#set! injection.language "powershell")
   (#set! injection.include-children)) @injection.content

--- a/tests/test_attributes.justfile
+++ b/tests/test_attributes.justfile
@@ -106,3 +106,8 @@ default-recipe:
 [private]
 combined:
     echo "Multiple attributes on one line"
+
+[arg('n', help='HELP')]
+[arg('n', pattern='\d+')]
+double n:
+    echo $(({{n}} * 2))


### PR DESCRIPTION
I've been running a fork of changes that I've been adding as well as
pulled from PRs that weren't merged upstream.

See changes: https://github.com/IndianBoy42/tree-sitter-just/compare/main...mattrobenolt:tree-sitter-just:main

This is mostly to keep up with newer features added in newer Just,
specifically support for `[arg(...)]` attributes.
