### PR TITLE
Add shebang support.

### DIFF
--- a/languages/just/config.toml
+++ b/languages/just/config.toml
@@ -1,6 +1,7 @@
 name = "Just"
 grammar = "just"
 path_suffixes = ["justfile", "Justfile", "JUSTFILE", "just"]
+first_line_pattern = '^#!.*\b(?:just)\b'
 line_comments = ["# "]
 brackets = [{ start = "(", end = ")", close = true, newline = true }]
 


### PR DESCRIPTION
Just supports shebang (#!) so it can run scripts with custom names.

https://github.com/casey/just#just-scripts

Works with something like this:

`#!/usr/bin/env -S just --justfile`